### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#### MaterialDesignColor ![Cocoapods Version](https://img.shields.io/cocoapods/v/MaterialDesignColor.svg?style=flat) ![Platform](https://img.shields.io/cocoapods/p/MaterialDesignColor.svg?style=flat) ![License](https://img.shields.io/cocoapods/l/MaterialDesignColor.svg?style=flat)
+#### MaterialDesignColor ![CocoaPods Version](https://img.shields.io/cocoapods/v/MaterialDesignColor.svg?style=flat) ![Platform](https://img.shields.io/cocoapods/p/MaterialDesignColor.svg?style=flat) ![License](https://img.shields.io/cocoapods/l/MaterialDesignColor.svg?style=flat)
 ==============
 
 ![image](https://s3.amazonaws.com/cocoacontrols_production/uploads/control_image/image/6689/iOS_Simulator_Screen_Shot_2015.06.09_23.45.20.png)


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
